### PR TITLE
Add the gems in the Gemfile to the load path.

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,5 @@
+require "bundler/setup"
+
 require "rack/request"
 require "rack/response"
 


### PR DESCRIPTION
If you install your bundled gems in a project specific directory as
opposed to installing them as system gems, then the gems will not be
found unless you setup bundler like this.

I was seeing the following exception without this change:

```
LoadError: cannot load such file -- rack/request
```
